### PR TITLE
Fix errors from the list name of the list.txt being used by fetchItemDetails

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -354,7 +354,8 @@ const slidesInit = () => {
       return text
         .split("\n")
         .map((id) => id.trim())
-        .filter((id) => id);
+        .filter((id) => id)
+        .slice(1);
     } catch (error) {
       console.error("Error fetching list.txt:", error);
       return [];


### PR DESCRIPTION
Fixes the following errors in the console from the script trying to fetch the name of the list (first line) in list.txt
```
  GET https://jellyfin.server/Items/-e%20TV%20and%20Movies 400 (Bad Request)
  HEAD https://jellyfin.server/Items/undefined/Images/Backdrop/0 net::ERR_ABORTED 400 (Bad Request)
  HEAD https://jellyfin.server/Items/undefined/Images/Logo net::ERR_ABORTED 400 (Bad Request)
```