### PR TITLE
fix: add userId to api call so isPlayed can be checked

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -493,7 +493,7 @@ const ApiUtils = {
       console.log("Fetching random items from server...");
 
       const response = await fetch(
-        `${STATE.jellyfinData.serverAddress}/Items?IncludeItemTypes=Movie,Series&Recursive=true&hasOverview=true&imageTypes=Logo,Backdrop&sortBy=Random&isPlayed=False&Limit=${CONFIG.maxItems}&Fields=Id`,
+        `${STATE.jellyfinData.serverAddress}/Items?userId=${STATE.jellyfinData.userId}&IncludeItemTypes=Movie,Series&Recursive=true&hasOverview=true&imageTypes=Logo,Backdrop&sortBy=Random&isPlayed=False&Limit=${CONFIG.maxItems}&Fields=Id`,
         {
           headers: this.getAuthHeaders()
         }


### PR DESCRIPTION
hiya, i noticed that the slideshow was showing users things they have already watched.

i'm pretty sure it's just because of the api call missing the `userId` field, causing the `isPlayed` flag to be useless.

unfortunately i'm not in a position to fully test it atm, but doing some basic curl requests with sortBy set to Name, a userId set, and flipping the isPlayed bool actually shows changes now (whereas without the userId no changes are observed).