### PR TITLE
add option to display plaintext title & hide logo

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -324,13 +324,31 @@
 }
 
 .logo {
-  max-height: 70%;
+  max-height: 60%;
   max-width: 100%;
   height: auto;
   width: auto;
   object-fit: contain;
   filter: brightness(1.5);
 }
+
+.slide-title {
+    position: absolute;
+    display: flex;
+    top: calc(50% - 5vh);
+    left: 4vw;
+    margin: 0;
+    padding: 0;
+    color: #fff;
+    font-size: 2.5rem;
+    font-weight: 700;
+    z-index: 5;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 90%;
+}
+
 
 .plot-container {
   position: absolute;
@@ -673,6 +691,11 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+  }
+  
+  /* don't show plaintext title on mobile due to space constraints */
+  .slide-title {
+      display: none;
   }
 }
 

--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -24,6 +24,8 @@ const CONFIG = {
   maxItems: 500,
   preloadCount: 3,
   fadeTransitionDuration: 500,
+  hideLogo: false,          // hides the logo from the slideshow view
+  showTitle: true,          // ← new: show a plain-text title
 };
 
 // State management
@@ -769,10 +771,11 @@ const SlideCreator = {
   /**
    * Creates a slide element for an item
    * @param {Object} item - Item data
+   * @param {string} name - Display name (item.Name)
    * @param {string} title - Title type (Movie/TV Show)
    * @returns {HTMLElement} Slide element
    */
-  createSlideElement(item, title) {
+  createSlideElement(item, name, title) {
     if (!item || !item.Id) {
       console.error("Invalid item data:", item);
       return null;
@@ -811,11 +814,29 @@ const SlideCreator = {
       alt: "logo",
       loading: "eager",
     });
+    
+        let logoContainer = null;
+        if (!CONFIG.hideLogo) {
+            const logo = SlideUtils.createElement("img", {
+                className: "logo high-quality",
+                src: `${serverAddress}/Items/${itemId}/Images/Logo?quality=75`,
+                alt: "Logo",
+                loading: "eager",
+            });
+            logoContainer = SlideUtils.createElement("div", {
+                className: "logo-container",
+            });
+            logoContainer.appendChild(logo);
+        }
 
-    const logoContainer = SlideUtils.createElement("div", {
-      className: "logo-container",
-    });
-    logoContainer.appendChild(logo);
+        let titleElement = null;
+        if (CONFIG.showTitle) {
+            titleElement = SlideUtils.createElement(
+                "h2",
+                { className: "slide-title" },
+                name
+            );
+        }
 
     const featuredContent = SlideUtils.createElement(
       "div",
@@ -864,9 +885,17 @@ const SlideCreator = {
     const detailButton = this.createDetailButton(itemId);
     const favoriteButton = this.createFavoriteButton(item);
     buttonContainer.append(detailButton, playButton, favoriteButton);
+    
+    if (logoContainer) {
+        slide.appendChild(logoContainer);
+    }
+    if (titleElement) {
+        slide.appendChild(titleElement);
+    }
 
     slide.append(
       logoContainer,
+      titleElement,
       backdropContainer,
       gradientOverlay,
       featuredContent,
@@ -1126,6 +1155,7 @@ const SlideCreator = {
 
       const slideElement = this.createSlideElement(
         item,
+        item.Name,
         item.Type === "Movie" ? "Movie" : "TV Show"
       );
 


### PR DESCRIPTION
this commit adds the ability to display the item's title in plaintext below the logo, if desired. additionally, the ability to hide the logo has been added, in case the user wants to just show a plain-text title rather than a logo.

in the CSS, the logo's `max-height` has been slightly modified to accommodate the inclusion of the title.

below is a screenshot of how it looks, courtesy of a friend of mine who tested this on a fresh Jellyfin install
![image](https://github.com/user-attachments/assets/67bd8efc-d86e-4b3e-860c-aa29f2c0ac26)

this is my very first github PR, let me know if i messed up anywhere