### PR TITLE
item & dots enhancements

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -189,19 +189,30 @@
 
 .dot {
   display: inline-block;
-  width: 0.5em;
-  height: 0.5em;
+  cursor: pointer;
+  height: 8px;
+  width: 8px;
   margin: 0 5px;
-  background-color: #cecece99;
+  background-color: #CCCCCC;
   border-radius: 50%;
   transform-origin: center;
-  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1),
-    background-color 0.5s ease-in-out;
+  transition: transform 0.03s ease-in-out,
+              background-color 0.03s ease-in-out;
+}
+
+.dot:hover {
+  transform: scale(1.3);
+  background-color: #E0E0E0;
 }
 
 .dot.active {
-  background-color: #fff;
+  background-color: #F0E0F0;
   transform: scale(1.7);
+}
+
+.dot.active:hover {
+  transform: scale(1.7);
+  background-color: #FFFFFF;
 }
 
 .slide {


### PR DESCRIPTION
this PR enhances the slideshow functionality, specifically regarding how the items displayed in the slideshow are sourced, and how the pagination dots are generated and updated

- **configuration for slideshow items:** a new configuration option: `slideshowitems` is introduced to specify the desired number of items to display on the homepage. an `enableRandom` option is also added to control whether missing slots should be filled with random items from the server.

- **dynamic pagination dots:** the number of pagination dots is no longer fixed at 5. instead, it is dynamically determined based on the configured `slideshowItems`. the code now ensures that the correct number of dots is created.

- **dot click functionality:** event listeners are added to the pagination dots, allowing users to jump directly to a specific slide by clicking the corresponding dot. CSS rules have been added to accomodate for this. i mainly focused on desktop/web for the CSS changes. it *works* on mobile, but some mobile-specific rules might need to be added to account for the smaller screen space

- **improved dot updating:** updateDots function refined to handle cases where there might be no dots, and to correctly determine the active dot index based on the total number of items being shown and the configured number of dots. it also includes an option to hide dots if the actual number of slideshow items is less than the configured number of dots.

- **flexible slideshow data loading:** the loadSlideshowData function is significantly refactored to prioritize fetching item IDs from a local list.txt file. if the list is empty or doesn't provide enough items, and `enableRandom` is true, it will now fetch additional random item IDs from the server to meet the desired `slideshowItems` count. the final list of items is then shuffled and potentially sliced to match the configured `slideshowItems`