### PR TITLE
Convert 3-letter country codes to 2-letter if necessary

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -489,12 +489,9 @@ const LocalizationUtils = {
 
     if (window.ApiClient && STATE.jellyfinData?.accessToken) {
       try {
-        const userId = window.ApiClient.getCurrentUserId();
-        if (userId) {
-          const userData = await window.ApiClient.getUser(userId);
-          if (userData.Configuration?.AudioLanguagePreference) {
-            locale = userData.Configuration.AudioLanguagePreference.toLowerCase();
-          }
+        const userData = window.ApiClient.getCurrentUser();
+        if (userData.Configuration?.AudioLanguagePreference) {
+          locale = userData.Configuration.AudioLanguagePreference.toLowerCase();
         }
       } catch (error) {
         console.warn("Could not fetch user language preference:", error);


### PR DESCRIPTION
This merge request improves on https://github.com/MakD/Jellyfin-Media-Bar/pull/80 by resolving 3-letter country codes to 2-letter if necessary. The user configuration can contain those. Example:
<img width="964" height="289" alt="grafik" src="https://github.com/user-attachments/assets/720c88ed-7389-4a94-8c6c-c2ebe780adaa" />
<img width="294" height="167" alt="grafik" src="https://github.com/user-attachments/assets/e398e5ac-564b-4949-acab-f07d0fd05722" />

It resolves them by requesting the countries.json from the Jellyfin server and then searching for the matching country.