### PR TITLE
Use scale3d to avoid stuttering on some browsers

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -28,11 +28,11 @@
 
 @keyframes kenBurnsZoomIn {
   from {
-    transform: scale(1);
+    transform: scale3d(1, 1, 0);
   }
 
   to {
-    transform: scale(1.1);
+    transform: scale3d(1.1, 1.1, 0.1);
   }
 }
 


### PR DESCRIPTION
The `scale` CSS function can cause the zoom-in animation to be unsmooth on some browsers (e.g. Firefox). Using `scale3d` with a changing z-component fixes this issue.

See also: https://gsap.com/community/forums/topic/28578-scale-transform-is-not-smooth-in-firefox

If you would like a demo video let me know.