### PR TITLE
Fix: Filter out media items without logo images

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -776,7 +776,7 @@ const ApiUtils = {
       console.log("Fetching random items from server...");
 
       const response = await fetch(
-        `${STATE.jellyfinData.serverAddress}/Items?IncludeItemTypes=Movie,Series&Recursive=true&hasOverview=true&imageTypes=Logo,Backdrop&sortBy=Random&isPlayed=False&enableUserData=true&Limit=${CONFIG.maxItems}&fields=Id`,
+        `${STATE.jellyfinData.serverAddress}/Items?IncludeItemTypes=Movie,Series&Recursive=true&hasOverview=true&imageTypes=Logo,Backdrop&sortBy=Random&isPlayed=False&enableUserData=true&Limit=${CONFIG.maxItems}&fields=Id,ImageTags`,
         {
           headers: this.getAuthHeaders(),
         }
@@ -796,7 +796,10 @@ const ApiUtils = {
         `Successfully fetched ${items.length} random items from server`
       );
 
-      return items.map((item) => item.Id);
+      return items
+        .filter(item => item.ImageTags && item.ImageTags.Logo)
+        .map((item) => item.Id);
+
     } catch (error) {
       console.error("Error fetching item IDs:", error);
       return [];


### PR DESCRIPTION
### Description
This PR modifies the `fetchItemIdsFromServer` function in `slideshowpure.js` to prevent media items without a logo from appearing in the slideshow.

### Motivation and Context
Currently, items without a logo are fetched and displayed using a generic placeholder which breaks the visual consistency of the media bar. Since there is no specific styling for these placeholders, it is better to simply exclude these items from the rotation.

### Changes
- Updated the API query to request `ImageTags` in the `fields` parameter.
- Added a `.filter()` step to ensure `item.ImageTags.Logo` exists before adding an item to the list.