### PR TITLE
Add `user-select: none` for non-clickable elements

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -468,9 +468,12 @@
   display: flex;
   align-items: flex-start;
   justify-content: flex-start;
-  text-align: justify;
+  text-align: left;
+  text-align: start;
+  text-wrap: balance;
   box-sizing: border-box;
   transition: width 0.5s ease-in-out;
+  max-width: 50rem;
 }
 
 .plot-container.with-video {
@@ -479,8 +482,8 @@
 
 .plot {
   display: -webkit-box;
-  line-clamp: 2;
-  -webkit-line-clamp: 2;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -120,6 +120,7 @@
 }
 
 .video-container {
+  user-select: none;
   position: absolute;
   top: 0;
   right: 0;
@@ -150,6 +151,7 @@
 }
 
 .video-player {
+  user-select: none;
   width: 100%;
   height: 100%;
 }
@@ -224,6 +226,7 @@
 }
 
 .arrow {
+  user-select: none;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -333,6 +336,7 @@
 }
 
 .backdrop-container {
+  user-select: none;
   position: absolute;
   top: 0%;
   right: 0%;
@@ -404,6 +408,7 @@
 }
 
 .gradient-overlay {
+  user-select: none;
   position: absolute;
   top: 0;
   left: 0;
@@ -439,6 +444,7 @@
   z-index: 5;
   top: 15vh;
   left: 4vw;
+  user-select: none;
 }
 
 .logo {
@@ -495,6 +501,7 @@
 }
 
 .button-container {
+  user-select: none;
   position: absolute;
   top: calc(50% + 17vh);
   left: 4vw;

--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -864,3 +864,10 @@
     top: calc(50% + 15vh);
   }
 }
+
+/* Fix ratings position */
+.mediaInfoOfficialRating {
+  &,&:hover {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
1. Add user-select: none for non-clickable elements
2. Limit plot width to 50rem

It was just looking bad on 34x9 wide screen with 90%.

<img width="801" height="219" alt="image" src="https://github.com/user-attachments/assets/0fdbaee6-ca66-4d5a-ab30-69edd582665f" />

3. Fix ratings position

Before
<img width="207" height="47" alt="image" src="https://github.com/user-attachments/assets/2c225ffd-97ce-4c76-aeac-a637d6182652" />

After
<img width="211" height="55" alt="image" src="https://github.com/user-attachments/assets/aebfcd83-0389-48d6-a6ca-7dae9701b087" />

