### PR TITLE
Fix missing backdrop to trailer fade in Firefox (invalid mask-composite value)

### DIFF
--- a/slideshowpure.css
+++ b/slideshowpure.css
@@ -421,7 +421,7 @@
     linear-gradient(to top, #fff0 2%, rgb(0 0 0 / 0.5) 6%, #000000 8%),
     linear-gradient(to right, black 30%, transparent 85%);
 
-  mask-composite: source-in;
+  mask-composite: intersect;
   -webkit-mask-composite: source-in;
 }
 


### PR DESCRIPTION
## Problem

When a trailer starts on the featured slide, the backdrop is meant to fade into the video. In Firefox there is no fade at all: the backdrop hard cuts against the trailer, leaving a vertical seam at exactly 40% of the viewport width. Chromium renders the intended blend.

## Cause

`.backdrop.with-video` combines its two mask layers with:

```css
mask-composite: source-in;
-webkit-mask-composite: source-in;
```

`source-in` is a `-webkit-mask-composite` value. The standard `mask-composite` property accepts only `add | subtract | intersect | exclude`, so the first declaration is invalid and is dropped (`CSS.supports('mask-composite', 'source-in')` returns `false`).

Chromium is saved by the `-webkit-` line that follows. Firefox does not apply that alias here, so nothing sets the property and it falls back to the initial value `add`. That unions the mask layers rather than intersecting them, so the `to right, black 30%, transparent 85%` layer no longer cuts anything and the fade disappears.

`intersect` is the standard equivalent of webkit's `source-in`. `.video-container` already uses the correct `intersect` / `source-in` pairing at lines 143 and 179, so this looks like a plain typo at line 424.

## Fix

One line. The `-webkit-mask-composite` line is left untouched, so Chromium behaviour is unchanged.

## Testing

Rendered the featured slide DOM against this stylesheet in headless Firefox 
and Chromium, using a 10% grid pattern in place of the trailer so the mask edge is measurable.

- Firefox before: hard seam at 40%
- Firefox after: intended fade, and the screenshot is byte identical to one produced by overriding only `mask-composite: intersect` on the unpatched file
- Chromium before and after: byte identical screenshots, confirming the change is a no-op there

## Credit

@dylmart diagnosed this independently in IAmParadox27/jellyfin-plugin-media-bar#161 and was asked to bring it here, which does not appear to have happened. Same finding, same fix.
