### PR TITLE
Pick the main trailer instead of RemoteTrailers[0]

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -24,9 +24,10 @@ const CONFIG = {
   enableTrailers: true,
   // Name fragments identifying alternate cuts of a trailer: accessibility
   // variants and social crops. Matched case insensitively against the
-  // RemoteTrailers entry name. These are ranked below every ordinary entry
-  // rather than removed, so an item whose only trailer is an alternate cut
-  // still plays something.
+  // RemoteTrailers entry name. These are demoted within their tier, so an
+  // alternate cut loses to an ordinary entry of the same tier but still
+  // beats lower tier promo clips, and an item whose only trailer is an
+  // alternate cut still plays something.
   trailerAlternateCutTerms: [
     "sign language",
     "asl trailer",
@@ -1219,7 +1220,9 @@ const SlideCreator = {
    * accessibility variant rather than the main trailer, and it is not
    * guaranteed to be a YouTube link at all. Entries are ranked by name, with
    * provider order breaking ties, and any entry that does not yield a video id
-   * is skipped instead of losing the trailer for that slide.
+   * is skipped instead of losing the trailer for that slide. Alternate cuts
+   * are demoted within their tier: they lose to an ordinary entry of the same
+   * tier but still beat lower tier promo clips.
    *
    * @param {Array} remoteTrailers - RemoteTrailers array from the item
    * @returns {string|null} YouTube video id, or null if no entry is usable
@@ -1243,7 +1246,7 @@ const SlideCreator = {
       else if (text.includes("teaser")) rank = 2;
       else rank = 1;
 
-      return isAlternateCut ? rank - 10 : rank;
+      return isAlternateCut ? rank - 0.5 : rank;
     };
 
     let best = null;
@@ -1251,7 +1254,18 @@ const SlideCreator = {
     for (const trailer of remoteTrailers) {
       let videoId = null;
       try {
-        videoId = new URL(trailer.Url).searchParams.get("v");
+        const urlObj = new URL(trailer.Url);
+        const host = urlObj.hostname.replace(/^www\./, "");
+        if (host === "youtu.be") {
+          videoId = urlObj.pathname.split("/")[1] || null;
+        } else if (
+          (host === "youtube.com" || host === "m.youtube.com") &&
+          urlObj.pathname.startsWith("/embed/")
+        ) {
+          videoId = urlObj.pathname.split("/")[2] || null;
+        } else {
+          videoId = urlObj.searchParams.get("v");
+        }
       } catch (e) {}
 
       if (!videoId) continue;

--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -22,6 +22,19 @@ const CONFIG = {
   fadeTransitionDuration: 500,
   slideAnimationEnabled: true,
   enableTrailers: true,
+  // Name fragments identifying alternate cuts of a trailer: accessibility
+  // variants and social crops. Matched case insensitively against the
+  // RemoteTrailers entry name. These are ranked below every ordinary entry
+  // rather than removed, so an item whose only trailer is an alternate cut
+  // still plays something.
+  trailerAlternateCutTerms: [
+    "sign language",
+    "asl trailer",
+    "audio description",
+    "audio described",
+    "described audio",
+    "vertical",
+  ],
   youtubeApiLoadTimeoutMs: 8000,
 };
 
@@ -1199,6 +1212,60 @@ const SlideCreator = {
   },
 
   /**
+   * Picks the YouTube video id of the most appropriate trailer for an item.
+   *
+   * RemoteTrailers arrives in metadata provider order, which is not preference
+   * order. The first entry is frequently a promo clip, a teaser or an
+   * accessibility variant rather than the main trailer, and it is not
+   * guaranteed to be a YouTube link at all. Entries are ranked by name, with
+   * provider order breaking ties, and any entry that does not yield a video id
+   * is skipped instead of losing the trailer for that slide.
+   *
+   * @param {Array} remoteTrailers - RemoteTrailers array from the item
+   * @returns {string|null} YouTube video id, or null if no entry is usable
+   */
+  selectTrailerVideoId(remoteTrailers) {
+    if (!Array.isArray(remoteTrailers) || remoteTrailers.length === 0) {
+      return null;
+    }
+
+    const rankName = (name) => {
+      const text = (name || "").toLowerCase();
+      const isAlternateCut = CONFIG.trailerAlternateCutTerms.some((term) =>
+        text.includes(term),
+      );
+
+      let rank;
+      if (text.includes("official trailer")) rank = 5;
+      else if (text.includes("final trailer") || text.includes("main trailer"))
+        rank = 4;
+      else if (text.includes("trailer")) rank = 3;
+      else if (text.includes("teaser")) rank = 2;
+      else rank = 1;
+
+      return isAlternateCut ? rank - 10 : rank;
+    };
+
+    let best = null;
+
+    for (const trailer of remoteTrailers) {
+      let videoId = null;
+      try {
+        videoId = new URL(trailer.Url).searchParams.get("v");
+      } catch (e) {}
+
+      if (!videoId) continue;
+
+      const rank = rankName(trailer.Name);
+      if (!best || rank > best.rank) {
+        best = { videoId, rank };
+      }
+    }
+
+    return best ? best.videoId : null;
+  },
+
+  /**
    * Creates a slide element for an item
    * @param {Object} item - Item data
    * @param {string} title - Title type (Movie/TV Show)
@@ -1221,15 +1288,8 @@ const SlideCreator = {
     let videoId = null;
     let trailerContainer = null;
 
-    if (
-      CONFIG.enableTrailers &&
-      item.RemoteTrailers &&
-      item.RemoteTrailers.length > 0
-    ) {
-      try {
-        const urlObj = new URL(item.RemoteTrailers[0].Url);
-        videoId = urlObj.searchParams.get("v");
-      } catch (e) {}
+    if (CONFIG.enableTrailers) {
+      videoId = this.selectTrailerVideoId(item.RemoteTrailers);
 
       if (videoId) {
         trailerContainer = SlideUtils.createElement("div", {


### PR DESCRIPTION
## Problem

`SlideCreator.createSlideElement` takes `item.RemoteTrailers[0]` unconditionally:

```js
const urlObj = new URL(item.RemoteTrailers[0].Url);
videoId = urlObj.searchParams.get("v");
```

`RemoteTrailers` arrives in metadata provider order, and that is not preference order. Index 0 is regularly a promo clip, a teaser, or an alternate cut rather than the actual trailer.

The most visible case is an American Sign Language trailer. TMDb lists `Official American Sign Language Trailer` first for A Minecraft Movie, and Jellyfin passes that order through untouched:

```
[0] Official American Sign Language Trailer   <- what the bar plays
[1] Vertical :60 Final Trailer [Subtitled]
[2] Final Trailer
[3] Official Trailer                          <- what you want
... 44 more
```

So the slide plays a cut with an interpreter composited into the bottom right corner, drawn over the backdrop and next to the logo and overview. Same for Mortal Kombat II and Superman.

There is a second, quieter failure. Index 0 is not guaranteed to be a YouTube link. When it is not, `searchParams.get("v")` returns `null`, no player is built, and the slide loses its trailer completely even though a perfectly good YouTube entry is sitting further down the same array.

## Change

Adds `SlideCreator.selectTrailerVideoId()`, which ranks entries by name instead of trusting position:

| Name contains | Rank |
| --- | --- |
| `official trailer` | 5 |
| `final trailer`, `main trailer` | 4 |
| `trailer` | 3 |
| `teaser` | 2 |
| anything else | 1 |

Entries matching `CONFIG.trailerAlternateCutTerms` (sign language, audio description, vertical crops) are demoted by half a rank, within their tier rather than to the bottom. An alternate cut of a real trailer still loses to an ordinary trailer of the same tier, but it stays above the promo clips and reviews in the `anything else` tier, and it is demoted rather than removed, so an item whose only trailer is an alternate cut still plays something instead of going silent.

Provider order breaks ties, so an item whose first entry is already the best keeps exactly what it has today. Entries that yield no video id are skipped rather than ending the search, which fixes the non-YouTube case. `youtu.be` short links and `youtube.com/embed` links carry no `v` query param, so those are parsed from the pathname instead of being skipped.

`enableTrailers` behaviour is unchanged, and `trailerAlternateCutTerms` is additive config with a working default.

## Testing

Assertions run against the real patched source, including the genuine 47 entry `RemoteTrailers` array for A Minecraft Movie pulled from a live Jellyfin 10.11 server:

```
SYNTAX OK
PASS  real 48-entry Minecraft list picks Official Trailer
PASS  ASL-only item still plays (degrades, not discards)
PASS  ASL trailer still beats non-trailer clips like Behind the Scenes
PASS  non-YouTube first entry no longer kills the trailer
PASS  provider order breaks ties at equal rank
PASS  teaser loses to trailer regardless of order
PASS  vertical social crop demoted
PASS  null Name is ranked, not crashed
PASS  empty array / undefined / null / malformed url
PASS  youtu.be and youtube.com/embed links resolve to ids
```

Then swept every item in my library that the bar can feature, comparing old pick against new:

```
384 items with trailers
  changed pick: 105    lost trailer: 0
```

A few of the 105:

| Title | Was | Now |
| --- | --- | --- |
| A Minecraft Movie | Official American Sign Language Trailer | Official Trailer |
| Superman | Official American Sign Language Trailer | Official Trailer |
| Mortal Kombat II | Official American Sign Language Trailer | Official Trailer II |
| Oppenheimer | Review | Official Trailer |
| Avatar | Back in Theatres | Special Edition Official Trailer |
| Moana 2 | Special Look | Official Trailer |
| Project X | "Craziest" | Official Trailer 2 |
| Skyfall | Official International Trailer | Official Trailer |

To be clear about scope: this is unit level plus a full library data sweep against live API responses. I have not run the patched v5.0.1 file end to end in a browser, since my server is served v4.0.6 through the plugin CDN, but the same code path and the same bug are present in both.

