### PR TITLE
Fix SlideTimer lifecycle

### DIFF
--- a/slideshowpure.js
+++ b/slideshowpure.js
@@ -2308,6 +2308,7 @@ const SlideshowManager = {
       }, CONFIG.shuffleInterval);
 
       STATE.slideshow.slideInterval.stop();
+      STATE.slideshow.slideInterval = null; // Ensure that updateCurrentSlide doesn't restart the timer
 
       await this.updateCurrentSlide(0);
 


### PR DESCRIPTION
This merge request sets `slideInterval` to `null` to fix the lifecycle of the first `SlideTimer`.

With the change of PR #114, a timer lifecycle error was revealed. The problem is that `updateCurrentSlide` restarts the current `SlideTimer` in `slideInterval` (which checks `!STATE.slideshow.isVideoPlaying`) before it gets overwritten with the next `SlideTimer` (that checks `VisibilityObserver.wasVisible`). This can be seen on a movie/show/... page and in the admin interface.

<details>
<summary>Lifecycle error evidence</summary>

Adding the following logs also reveals that the second `SlideTimer` cannot take over because it's repeatedly interrupted by the first one. Calling "start"/"stop" never works because it only affects the second timer, not the first one (of which the reference is lost).
<img width="676" height="482" alt="grafik" src="https://github.com/user-attachments/assets/9167dac6-d5fb-43f6-8cf8-d17843875f3e" />

Logs:
<img width="745" height="463" alt="grafik" src="https://github.com/user-attachments/assets/63de29e4-5a23-436e-a90f-30685f79d314" />
</details>

Stack:
- SlideTimer#restart
- fallbackToTimer
- updateCurrentSlide
- loadSlideshowData